### PR TITLE
Improved behaviour of skeleton generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+
+# var files to keep credentials
+secrets.auto.tfvars

--- a/scenarios/skeleton.sh
+++ b/scenarios/skeleton.sh
@@ -6,26 +6,45 @@ if [[ -z $1 ]]; then
   exit 1
 fi
 
+FORCE=0
+if [[ "$2" == "--force" ]]; then
+    FORCE=1
+    echo "All existing files will be overwritten"
+fi
+
 target_name="$1"
 project_root=$(sh ./core/get_project_root.sh)
 
 cd "${project_root}" || exit 2
-scn_folder="${project_root}/scenarios/${target_name}"
-mkdir -p "${scn_folder}"
-
-shebang="#!/usr/bin/env bash\n"
+target_dir="${project_root}/scenarios/${target_name}"
+mkdir -p "${target_dir}"
 
 function init_if_missing() {
-    f_path="${scn_folder}/$1"
+    f_path="${target_dir}/$1"
     data="$2"
-    if [[ ! -e ${f_path} ]]; then
+    if [[ ! -e ${f_path} || "${FORCE}" == "1" ]]; then
         echo "${data}" > "${f_path}"
+        echo "File ${f_path} initialized."
+    else
+        echo "File ${f_path} already exists."
     fi
-    echo "File ${f_path} initialized"
+
 }
 
+# initialize terraform + some scripts
+shebang="#!/usr/bin/env bash"
 init_if_missing "pre_build.sh" "${shebang}"
 init_if_missing "post_build.sh" "${shebang}"
+init_if_missing "terraform.tfvars" \
+"region = \"eu-de\"
+tenant_name = \"eu-de_rus\"
+default_az = \"eu-de-01\"
+domain_name = \"OTC00000000001000000447\""
+init_if_missing "secrets.auto.tfvars" \
+"username = \"\"
+password = \"\""
+# let's pretend that target_dir is playbooks dir and create empty ansible playbook
+target_dir="${project_root}/playbooks" init_if_missing "${target_name}_setup.yml" "---"
 
 tf_template="terraform {
   required_providers {
@@ -35,17 +54,19 @@ tf_template="terraform {
 
 variable \"username\" {}
 variable \"password\" {}
+variable \"region\" {}
+variable \"tenant_name\" {}
+variable \"default_az\" {}
+variable \"domain_name\" {}
 
 # Configure the OpenTelekomCloud Provider
 provider \"opentelekomcloud\" {
   user_name = var.username
   password = var.password
-  domain_name = \"OTC00000000001000000447\"
-  tenant_name = \"eu-de_rus\"
+  domain_name = var.domain_name
+  tenant_name = var.tenant_name
   auth_url = \"https://iam.eu-de.otc.t-systems.com:443/v3\"
-}
-"
+}"
 init_if_missing "infrastructure.tf" "${tf_template}"
-terraform init "${scn_folder}"
-
-touch "${project_root}/playbooks/scenarios/${target_name}_setup.yml"
+cd "${target_dir}" || exit 2
+terraform init


### PR DESCRIPTION
This PR add some variables to generated `.tf` file, fix errors in `.sh` scripts and chage out dir for ansible playbook to `playbooks/` as per https://github.com/opentelekomcloud-infra/csm-sandbox/issues/11