### PR TITLE
Add timeout for sending metrics to telegraf

### DIFF
--- a/scenarios/scenario1/test/continuous.py
+++ b/scenarios/scenario1/test/continuous.py
@@ -45,7 +45,7 @@ class Client:
         """Report metric to the server in new thread"""
 
         def _post_data():
-            res = self.session.post("/telegraf", data=str(metrics))
+            res = self.session.post("/telegraf", data=str(metrics), timeout=2)
             assert res.status_code == 204, f"Status is {res.status_code}"
 
         Thread(target=_post_data).start()


### PR DESCRIPTION
After some time, connection to telegraf hangs with socket state CLOSE_WAIT on the client. Seems that can be avoided adding timeout to request sending